### PR TITLE
aidbox-sql-functions: incorrect use of knife_extract_text in example

### DIFF
--- a/reference/aidbox-sql-functions.md
+++ b/reference/aidbox-sql-functions.md
@@ -11,7 +11,7 @@ This page is in progress. Please [contact us](broken-reference) if you need more
 ### knife\_extract
 
 ```sql
-knife_extract(data::jsonb, paths::jsonb) -> text[] 
+knife_extract(data::jsonb, paths::jsonb) -> jsonb[] 
 ```
 
 Extract elements from jsonb `data` given jsonb array of paths `paths`.&#x20;

--- a/reference/aidbox-sql-functions.md
+++ b/reference/aidbox-sql-functions.md
@@ -11,7 +11,7 @@ This page is in progress. Please [contact us](broken-reference) if you need more
 ### knife\_extract
 
 ```sql
-knife_extract_text(data::jsonb, paths::jsonb) -> text[] 
+knife_extract(data::jsonb, paths::jsonb) -> text[] 
 ```
 
 Extract elements from jsonb `data` given jsonb array of paths `paths`.&#x20;


### PR DESCRIPTION
The example mentions `knife_extract_text` where-as the section is about `knife_extract`.