### PR TITLE
Update setup-aidbox-with-fhir-schema-validation-engine.md

### DIFF
--- a/docs/modules/profiling-and-validation/fhir-schema-validator/setup-aidbox-with-fhir-schema-validation-engine.md
+++ b/docs/modules/profiling-and-validation/fhir-schema-validator/setup-aidbox-with-fhir-schema-validation-engine.md
@@ -33,7 +33,7 @@ AIDBOX_FHIR_PACKAGES=hl7.fhir.r4.core#4.0.1
 To validate coded values with an external Terminology service, set it in the following environment variable.
 
 ```
-AIDBOX_TERMINOLOGY_SERVICE_BASE_URL=https://tx.fhir.org/r4
+AIDBOX_TERMINOLOGY_SERVICE_BASE_URL=https://tx.health-samurai.io/fhir
 ```
 
 {% hint style="warning" %}


### PR DESCRIPTION
https://tx.fhir.org/r4 terminology server doesn't work for AidboxSubscriptionTopic, AidboxSubscriptionDestination, and AidboxSubscriptionStatus.

If you set AIDBOX_TERMINOLOGY_SERVICE_BASE_URL to https://tx.fhir.org/r4, you won't be able to create certain resources in Aidbox. In case of AidboxSubscriptionTopic this is because the resource uses http://hl7.org/fhir/ValueSet/interaction-trigger ValueSet for the trigger.supportedInteraction field, and this ValueSet is only present in FHIR R4B and R5, but not in R4. So the terminology server is not aware of it and considers the resource invalid.