### PR TITLE
Update fhir_schema_doc.clj

### DIFF
--- a/bb/fhir_schema_doc.clj
+++ b/bb/fhir_schema_doc.clj
@@ -26,7 +26,7 @@ To begin using FHIR IGs, enable the FHIR Schema validator engine in Aidbox.
 ```bash
 AIDBOX_FHIR_SCHEMA_VALIDATION=true
 AIDBOX_FHIR_PACKAGES=hl7.fhir.us.core#5.0.1:hl7.fhir.us.mcode#3.0.0
-AIDBOX_TERMINOLOGY_SERVICE_BASE_URL=https://tx.fhir.org/r4
+AIDBOX_TERMINOLOGY_SERVICE_BASE_URL=https://tx.health-samurai.io/fhir
 ```
 {% endcode %}
 


### PR DESCRIPTION
https://tx.fhir.org/r4 terminology server doesn't work for Aidbox-specific resources, such as AidboxSubscriptionTopic. If you set AIDBOX_TERMINOLOGY_SERVICE_BASE_URL to https://tx.fhir.org/r4, you won't be able to create certain resources in Aidbox.