### PR TITLE
Update aidbox-fhir-igs-registry.md

### DIFF
--- a/docs/modules/profiling-and-validation/fhir-schema-validator/aidbox-fhir-igs-registry.md
+++ b/docs/modules/profiling-and-validation/fhir-schema-validator/aidbox-fhir-igs-registry.md
@@ -20,7 +20,7 @@ To begin using FHIR IGs, enable the FHIR Schema validator engine in Aidbox.
 ```bash
 AIDBOX_FHIR_SCHEMA_VALIDATION=true
 AIDBOX_FHIR_PACKAGES=hl7.fhir.us.core#5.0.1:hl7.fhir.us.mcode#3.0.0
-AIDBOX_TERMINOLOGY_SERVICE_BASE_URL=https://tx.fhir.org/r4
+AIDBOX_TERMINOLOGY_SERVICE_BASE_URL=https://tx.health-samurai.io/fhir
 ```
 {% endcode %}
 


### PR DESCRIPTION
https://tx.fhir.org/r4 terminology server doesn't work for AidboxSubscriptionTopic, AidboxSubscriptionDestination, and AidboxSubscriptionStatus.

If you set AIDBOX_TERMINOLOGY_SERVICE_BASE_URL to https://tx.fhir.org/r4, you won't be able to create certain resources in Aidbox. In case of AidboxSubscriptionTopic this is because the resource uses http://hl7.org/fhir/ValueSet/interaction-trigger ValueSet for the trigger.supportedInteraction field, and this ValueSet is only present in FHIR R4B and R5, but not in R4. So the terminology server is not aware of it and considers the resource invalid.