### PR TITLE
Update deploy-production-ready-aidbox-to-kubernetes.md

### DIFF
--- a/docs/deployment-and-maintenance/deploy-aidbox/run-aidbox-in-kubernetes/deploy-production-ready-aidbox-to-kubernetes.md
+++ b/docs/deployment-and-maintenance/deploy-aidbox/run-aidbox-in-kubernetes/deploy-production-ready-aidbox-to-kubernetes.md
@@ -250,7 +250,7 @@ metadata:
 data:
   AIDBOX_BASE_URL: https://my.box.url
   AIDBOX_FHIR_PACKAGES: 'hl7.fhir.r4.core#4.0.1' # your packages
-  AIDBOX_TERMINOLOGY_SERVICE_BASE_URL: 'https://tx.fhir.org/r4'
+  AIDBOX_TERMINOLOGY_SERVICE_BASE_URL: 'https://tx.health-samurai.io/fhir'
   AIDBOX_BOX_ID: aidbox
   AIDBOX_PORT: '8080'
   AIDBOX_STDOUT_PRETTY: all


### PR DESCRIPTION
https://tx.fhir.org/r4 terminology server doesn't work for Aidbox-specific resources, such as AidboxSubscriptionTopic. If you set AIDBOX_TERMINOLOGY_SERVICE_BASE_URL to https://tx.fhir.org/r4, you won't be able to create certain resources in Aidbox.