### PR TITLE
Fix typo in user reference in Apple tutorial

### DIFF
--- a/docs/tutorials/security-access-control-tutorials/apple.md
+++ b/docs/tutorials/security-access-control-tutorials/apple.md
@@ -120,7 +120,7 @@ Make sure you have selected **"Share my email"** option.
 
 Since no access policy has been assigned to your user yet, you won’t see much in Aidbox.
 
-Log in again as an admin, then navigate to **IAM -> User** to check the iser created in Aidbox for your Apple account. Click on the user ID to view details.
+Log in again as an admin, then navigate to **IAM -> User** to check the user created in Aidbox for your Apple account. Click on the user ID to view details.
 
 <figure><img src="../../.gitbook/assets/44910356-d93a-44cd-b0fd-9a87fbe3769c.png" alt="Apple user in Aidbox IAM Users list"><figcaption></figcaption></figure>
 


### PR DESCRIPTION
Fixed a typo: ‘iser’ → ‘user’ in Apple IAM tutorial.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Fixes a typo in the Apple SSO access-control tutorial by correcting “iser” to “user” in the step that instructs admins to verify the created IAM user.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db82d4749d8029e25970567a81fd0e08327851ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->